### PR TITLE
Listener Startup Event

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    subserver (0.2.2)
+    subserver (0.3.0)
       google-cloud-pubsub (~> 0.31, >= 0.31.0)
 
 GEM
@@ -77,7 +77,7 @@ GEM
       googleauth (~> 0.6.2)
       grpc (>= 1.7.2, < 2.0)
       rly (~> 0.2.3)
-    google-protobuf (3.6.1)
+    google-protobuf (3.6.1-universal-darwin)
     googleapis-common-protos (1.3.7)
       google-protobuf (~> 3.0)
       googleapis-common-protos-types (~> 1.0)
@@ -91,7 +91,7 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (~> 0.7)
-    grpc (1.15.0)
+    grpc (1.15.0-universal-darwin)
       google-protobuf (~> 3.1)
       googleapis-common-protos-types (~> 1.0.0)
     grpc-google-iam-v1 (0.6.9)

--- a/lib/subserver.rb
+++ b/lib/subserver.rb
@@ -26,6 +26,7 @@ module Subserver
     death_handlers: [],
     lifecycle_events: {
       startup: [],
+      listener_startup: [],
       quiet: [],
       shutdown: [],
       heartbeat: [],

--- a/lib/subserver/cli.rb
+++ b/lib/subserver/cli.rb
@@ -88,8 +88,8 @@ module Subserver
         end
       end
 
-      # Before this point, the process is initializing with just the main thread.
-      # Starting here the process will now have multiple threads running.
+      # Until this point, the process is initializing with just the main thread.
+      # After this point the process will have multiple threads running.
       fire_event(:startup, reverse: false, reraise: true)
 
       logger.debug { "Middleware: #{Subserver.middleware.map(&:klass).join(', ')}" }

--- a/lib/subserver/listener.rb
+++ b/lib/subserver/listener.rb
@@ -90,6 +90,8 @@ module Subserver
 
     def run
       begin
+        # This begins the listener process in a forked thread
+        fire_event(:listener_startup, reverse: false, reraise: true)
         connect_subscriber
         @pubsub_listener.start
       rescue Subserver::Shutdown

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,8 @@ RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.
+  config.filter_run_when_matching :focus
+
   config.expect_with :rspec do |expectations|
     # This option will default to `true` in RSpec 4. It makes the `description`
     # and `failure_message` of custom matchers include text for helper methods
@@ -78,8 +80,8 @@ RSpec.configure do |config|
     topic = client.topic "test"
     if topic.nil?
       topic = client.create_topic "test"
-      subscription = topic.subscribe "test-subscriber-1"
-      subscription = topic.subscribe "test-subscriber-2"
+      subscription = topic.subscribe "test-subscription-1"
+      subscription = topic.subscribe "test-subscription-2"
     end
   end 
 
@@ -91,7 +93,7 @@ RSpec.configure do |config|
   # is tagged with `:focus`, all examples get run. RSpec also provides
   # aliases for `it`, `describe`, and `context` that include `:focus`
   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
+  
 
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend

--- a/spec/subserver_spec.rb
+++ b/spec/subserver_spec.rb
@@ -1,4 +1,6 @@
 require 'spec_helper'
+require_relative '../lib/subserver/listener'
+require_relative '../lib/subserver/manager'
 
 RSpec.describe Subserver do
 
@@ -15,6 +17,48 @@ RSpec.describe Subserver do
   describe 'load config' do
     it 'loads when file exists'
     it 'errors when file doesn\'t exit'
+  end
+
+  describe 'live cycle events' do
+
+    let(:testclass) {
+      Class.new do 
+        def ping
+          true
+        end
+      end
+    }
+
+    let(:test_subscriber) { 
+      Class.new do 
+        include Subserver::Subscriber 
+        subserver_options subscription: "test-subscription-1"
+
+        def perform
+          true
+        end
+      end
+    }
+
+    before do
+      @tester = testclass.new
+      Subserver.configure do |config|
+        config.on(:listener_startup) do 
+          @tester.ping
+        end 
+      end
+
+      @manager = instance_double("Subserver::Manager")
+      allow(@manager).to receive(:options) { Subserver.options }
+    end
+
+    describe 'listener_startup event' do
+      it 'runs when listener started', focus: true do
+        expect(@tester).to receive(:ping)
+        listener = Subserver::Listener.new(@manager, test_subscriber)
+        listener.fire_event(:listener_startup, reverse: false, reraise: true)
+      end
+    end
   end
   
 end

--- a/spec/subserver_spec.rb
+++ b/spec/subserver_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Subserver do
     end
 
     describe 'listener_startup event' do
-      it 'runs when listener started', focus: true do
+      it 'runs when listener started' do
         expect(@tester).to receive(:ping)
         listener = Subserver::Listener.new(@manager, test_subscriber)
         listener.fire_event(:listener_startup, reverse: false, reraise: true)


### PR DESCRIPTION
Add new listener startup life cycle event to allow objects to be created after listeners are forked