### PR TITLE
Fix Listener#process_message error handling

### DIFF
--- a/lib/subserver/listener.rb
+++ b/lib/subserver/listener.rb
@@ -112,9 +112,12 @@ module Subserver
       rescue Subserver::Shutdown
         # Reject message if shutdown
         received_message.reject!
-      rescue Exception => ex
-        handle_exception(e, { context: "Exception raised during message processing.", message: received_message })
-        raise e
+      rescue StandardError => error
+        handle_exception error, {
+          context: 'Exception raised during message processing.',
+          message: received_message
+        }
+        raise
       end
     end
 


### PR DESCRIPTION
Fixes #18 by:

* Fix the variable typo that collects the rescued error
* Rescues StandardError instead of Exception (See ["Rescue StandardError, Not Exception"](https://thoughtbot.com/blog/rescue-standarderror-not-exception))