### PR TITLE
Call auto-subscription to topics for subscribers that implement it

### DIFF
--- a/lib/subserver/manager.rb
+++ b/lib/subserver/manager.rb
@@ -35,7 +35,7 @@ module Subserver
       @listeners = Set.new
 
       subscribers.each do |subscriber|
-        subscriber.auto_subscribe if subscriber.auto_subscribe?
+        next if subscriber.auto_subscribe? && !subscriber.auto_subscribe
         @listeners << Listener.new(self, subscriber)
       end
 

--- a/lib/subserver/manager.rb
+++ b/lib/subserver/manager.rb
@@ -35,7 +35,7 @@ module Subserver
       @listeners = Set.new
 
       subscribers.each do |subscriber|
-        subscriber.ensure_subscription_exists if subscriber.can_auto_subscribe?
+        subscriber.auto_subscribe if subscriber.auto_subscribe?
         @listeners << Listener.new(self, subscriber)
       end
 

--- a/lib/subserver/manager.rb
+++ b/lib/subserver/manager.rb
@@ -30,7 +30,7 @@ module Subserver
     def initialize(options={})
       logger.debug { options.inspect }
       @options = options
-
+      
       @done = false
       @listeners = Set.new
 

--- a/lib/subserver/manager.rb
+++ b/lib/subserver/manager.rb
@@ -30,11 +30,12 @@ module Subserver
     def initialize(options={})
       logger.debug { options.inspect }
       @options = options
-      
+
       @done = false
       @listeners = Set.new
 
       subscribers.each do |subscriber|
+        subscriber.ensure_subscription_exists if subscriber.can_auto_subscribe?
         @listeners << Listener.new(self, subscriber)
       end
 

--- a/lib/subserver/subscriber.rb
+++ b/lib/subserver/subscriber.rb
@@ -11,9 +11,8 @@ module Subserver
     end
 
     module ClassMethods
-
-      def can_auto_subscribe?
-        respond_to? :ensure_subscription_exists
+      def auto_subscribe?
+        respond_to? :auto_subscribe
       end
 
       def subserver_options(opts={})

--- a/lib/subserver/subscriber.rb
+++ b/lib/subserver/subscriber.rb
@@ -12,13 +12,17 @@ module Subserver
 
     module ClassMethods
 
+      def can_auto_subscribe?
+        respond_to? :ensure_subscription_exists
+      end
+
       def subserver_options(opts={})
         self.subserver_options_hash = get_subserver_options.merge(opts)
       end
 
       def get_subserver_options
         self.subserver_options_hash ||= Subserver.default_subscriber_options
-      end 
+      end
 
       def subserver_class_attribute(*attrs)
         instance_reader = true

--- a/lib/subserver/subscriber.rb
+++ b/lib/subserver/subscriber.rb
@@ -21,7 +21,7 @@ module Subserver
 
       def get_subserver_options
         self.subserver_options_hash ||= Subserver.default_subscriber_options
-      end
+      end 
 
       def subserver_class_attribute(*attrs)
         instance_reader = true

--- a/spec/fixtures/files/example_subscribers/auto_subscribing_subscriber.rb
+++ b/spec/fixtures/files/example_subscribers/auto_subscribing_subscriber.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AutoSubscribingSubscriber
+  include Subserver::Subscriber
+  subserver_options subscription: 'your-gcloud-subscription-name'
+
+  def perform(message)
+    # do something with message
+    message.acknowledge!
+  end
+
+  def self.auto_subscribe
+    true
+  end
+end

--- a/spec/fixtures/files/example_subscribers/failing_auto_subscribing_subscriber.rb
+++ b/spec/fixtures/files/example_subscribers/failing_auto_subscribing_subscriber.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class FailingAutoSubscribingSubscriber
+  include Subserver::Subscriber
+  subserver_options subscription: 'your-gcloud-subscription-name'
+
+  def self.auto_subscribe
+    false
+  end
+end

--- a/spec/manager_spec.rb
+++ b/spec/manager_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+require_relative '../lib/subserver/manager'
+require_relative '../lib/subserver/listener'
+require_relative '../lib/subserver/subscriber'
+require_relative 'fixtures/files/example_subscribers/auto_subscribing_subscriber'
+require_relative 'fixtures/files/example_subscribers/failing_auto_subscribing_subscriber'
+
+RSpec.describe Subserver::Manager do
+  let(:example_options) { { queues: %w[default] } }
+
+  subject { described_class.new example_options }
+
+  describe 'initialization' do
+    context 'when a subscriber class implements .auto_subscribe' do
+      before do
+        allow(Subserver::Pubsub).to receive(:client).and_return(
+          double("book", subscription: 'subscription')
+        )
+      end
+
+      it 'calls .auto_subscribe before adding to the listeners list' do
+        expect(AutoSubscribingSubscriber).to receive :auto_subscribe
+        subject
+      end
+
+      context 'when it succeeds in subscribing' do
+        it 'makes it into the listeners list' do
+          expect(subject.listeners).to include an_object_having_attributes(
+            subscriber: AutoSubscribingSubscriber
+          )
+        end
+      end
+
+      context 'when it fails to subscribe' do
+        it "doesn't make it into the listeners list" do
+          expect(subject.listeners).not_to include an_object_having_attributes(
+            subscriber: FailingAutoSubscribingSubscriber
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/subscriber_spec.rb
+++ b/spec/subscriber_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+require_relative '../lib/subserver/subscriber'
+
+RSpec.describe Subserver::Subscriber do
+  let :example_subscriber_class do
+    Class.new do
+      include Subserver::Subscriber
+    end
+  end
+
+  describe '.auto_subscribe?' do
+    context 'when the subscriber class does not implement .auto_subscribe' do
+      it 'returns false' do
+        expect(example_subscriber_class.auto_subscribe?).to be false
+      end
+    end
+
+    context 'when the subscriber class implements .auto_subscribe' do
+      let :example_subscriber_class do
+        Class.new do
+          include Subserver::Subscriber
+          def self.auto_subscribe; true; end
+        end
+      end
+
+      it 'returns true' do
+        expect(example_subscriber_class.auto_subscribe?).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What does this PR do?

Implements the plumbing that would enable subscribers to automatically create a subscription to a topic, if the Subscriber class implements how to do it.

This feature would be required for #17